### PR TITLE
Fixed issue, when sending attachments

### DIFF
--- a/urpautils/universal.py
+++ b/urpautils/universal.py
@@ -67,7 +67,7 @@ def send_email_notification(
     smtp_server: str,
     smtp_port: int = 0,
     attachments: List[str] = [],
-    debug_level: int = 0
+    debug_level: int = 0,
 ) -> None:
     """Sends an e-mail
 


### PR DESCRIPTION
This commit includes the fix for sending email with attachments. I created new MIMEMultipart("mixed") and inside it, I put MIMEMultipart("alternative"), which includes html part and text part.