### PR TITLE
Add function to insert timestamp to filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.7.0] 2022-11-10
+### Added
+- [#19](https://github.com/ultimaterpa/urpautils/issues/19) : function `robot_has_time`
+
 ## [0.6.0] 2022-09-15
 ### Added
 - [#15](https://github.com/ultimaterpa/urpautils/pull/15) : decorator `repeat` for repeating an action on element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.8.0] - 2023-09-11
+### Added
+- [#22](https://github.com/ultimaterpa/urpautils/issues/22) : function `add_timestamp_to_filename` which adds a timestamp to the file name in the given absolute file path.
 ## [0.7.0] 2022-11-10
 ### Added
 - [#19](https://github.com/ultimaterpa/urpautils/issues/19) : function `robot_has_time`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ urpautils.prepare_dir("C:\\path\\to\\dir")
 #   'offset': integer saying which file to copy starting from the end (0->last file, 1->second last file, ...)
 newly_created_image_path = urpautils.copy_error_img("C:\\path\\to\\destination_directory")
 
+# Add timestamp to file name
+# This function takes an absolute file path and an optional timestamp format as inputs (default is '%Y-%m-%d').
+# It adds a timestamp to the file name and returns the new absolute file path.
+new_file_path = urpautils.add_timestamp_to_filename(
+    "C:\\path\\to\\file.txt"
+)
 ```
 
 ### Universal utilities for working with CSV files

--- a/urpautils/__about__.py
+++ b/urpautils/__about__.py
@@ -1,7 +1,7 @@
 """Information about urpautils module."""
 __title__ = "urpautils"
 __description__ = "Module containig universal functions used with UltimateRPA robots"
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __author__ = "anerold"
 __author_email__ = "support@ultimaterpa.cz"
 __url__ = "https://github.com/ultimaterpa/urpautils"

--- a/urpautils/file_utils.py
+++ b/urpautils/file_utils.py
@@ -278,7 +278,7 @@ def copy_error_img(
     return error_img_path_output
 
 
-def add_timestamp_to_filename(abs_path: str, timestamp_format: str = '%Y-%m-%d') -> str:
+def add_timestamp_to_filename(abs_path: str, timestamp_format: str = "%Y-%m-%d") -> str:
     """
     This function takes an absolute file path and a timestamp format as inputs.
     It adds a timestamp to the file name and returns the new absolute file path.

--- a/urpautils/file_utils.py
+++ b/urpautils/file_utils.py
@@ -1,5 +1,6 @@
 """Module containing universal functions for file operations that can be used with urpa robots"""
 
+import datetime
 import glob
 import json
 import logging
@@ -275,3 +276,19 @@ def copy_error_img(
     error_img_path_output = os.path.join(output_dir, output_file_name)
     shutil.copyfile(error_img_path_log, error_img_path_output)
     return error_img_path_output
+
+
+def add_timestamp_to_filename(abs_path: str, timestamp_format: str = '%Y-%m-%d') -> str:
+    """
+    This function takes an absolute file path and a timestamp format as inputs.
+    It adds a timestamp to the file name and returns the new absolute file path.
+
+    :param abs_path: The absolute path to the file
+    :param timestamp_format: The format of the timestamp to be added (default is '%Y-%m-%d')
+    :return: The new absolute path with the timestamp added to the file name
+    """
+    path, base = os.path.split(abs_path)
+    filename, ext = os.path.splitext(base)
+    timestamp = datetime.datetime.now().strftime(timestamp_format)
+    new_filename = f"{timestamp}_{filename}{ext}"
+    return os.path.join(path, new_filename)


### PR DESCRIPTION
**Description:**

In this pull request, we are introducing a new utility function named add_timestamp_to_filename. This function will help in inserting a timestamp at the beginning of the file names which is a common practice in our project for file management. It accepts an absolute file path and an optional timestamp format as inputs.

**Related Issue:**

Closes #22

**Usage Example:**

```
new_file_path = urpautils.add_timestamp_to_filename(
    "C:\\path\\to\\file.txt",
    timestamp_format="%Y-%m-%d"
)
```

**Documentation:**

Updated README with the usage example.
Updated Changelog with the new feature details.