### PR TITLE
Add 'is_account_number_valid' function for account number validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.0] - 2023-11-16
+### Added
+- New function `is_account_number_valid` to validate account numbers using a weighted checksum algorithm, ensuring their compliance with ECBS standards.
+
 ## [0.8.0] - 2023-09-11
 ### Added
 - [#22](https://github.com/ultimaterpa/urpautils/issues/22) : function `add_timestamp_to_filename` which adds a timestamp to the file name in the given absolute file path.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ def click_ok() -> None:
 # Verify Personal Identification Number (Rodné číslo)
 is_valid = urpautils.verify_rc("990512/1234")
 
+# Verify account number
+is_valid = urpautils.is_account_number_valid(prefix="000000", account_number="1234567890")
+
 # Verify BIN (IČO)
 is_valid = urpautils.verify_ico("12345678")
 

--- a/tests/test_universal.py
+++ b/tests/test_universal.py
@@ -215,3 +215,35 @@ def test_robot_has_time_valueerror():
         universal.robot_has_time("24:00:00")
     with pytest.raises(ValueError):
         universal.robot_has_time(start="0:00:00", end="11-12-25")
+
+
+class TestIsAccountNumberValid:
+    """Test is_account_number_valid() function"""
+
+    @pytest.mark.parametrize(
+        "prefix, account_number",
+        [
+            ("000019", "2235210247"),
+            ("006007", "0700103393"),
+        ],
+    )
+    def test_valid_account_numbers(self, prefix, account_number):
+        assert universal.is_account_number_valid(prefix, account_number)
+
+    @pytest.mark.parametrize(
+        "prefix, account_number",
+        [
+            ("000000", "1234567890"),
+            ("111111", "9876543210"),
+        ],
+    )
+    def test_invalid_account_numbers(self, prefix, account_number):
+        assert not universal.is_account_number_valid(prefix, account_number)
+
+    def test_invalid_input_types(self):
+        # Invalid the prefix part of the account number
+        with pytest.raises(ValueError):
+            universal.is_account_number_valid(12345, "67890")
+        # Invalid the main part of the account number
+        with pytest.raises(ValueError):
+            universal.is_account_number_valid("12345", 67890)

--- a/urpautils/universal.py
+++ b/urpautils/universal.py
@@ -409,3 +409,32 @@ def robot_has_time(start: str = "00:00:00", end: str = "23:59:59") -> bool:
             end_time = end_time + datetime.timedelta(days=1)
 
     return start_time <= now <= end_time
+
+
+def is_account_number_valid(prefix: str, account_number: str) -> bool:
+    """
+    Validates an account number based on a specific weight system.
+
+    This function uses a predefined set of weights to validate the given prefix and account number.
+    Both the prefix and the account number are validated separately. Each digit of the prefix and
+    the account number is multiplied by a corresponding weight, and the sum of these products must
+    be divisible by 11 for the number to be considered valid.
+
+    :param prefix:                  str, The prefix part of the account number.
+    :param account_number:          str, The main part of the account number.
+    :return                         bool, True if the account number is valid, False otherwise.
+    """
+    # https://www.ecbs.org/Download/Tr201v3.9.pdf
+    weights = [6, 3, 7, 9, 10, 5, 8, 4, 2, 1]
+    prefix_sum = 0
+    for digit, weight in zip(prefix, weights[-6:]):
+        prefix_sum += int(digit) * weight
+    prefix_remainder = prefix_sum % 11
+    if prefix_remainder != 0:
+        return False
+
+    account_number_sum = 0
+    for digit, weight in zip(account_number, weights):
+        account_number_sum += int(digit) * weight
+    account_number_remainder = account_number_sum % 11
+    return account_number_remainder == 0

--- a/urpautils/universal.py
+++ b/urpautils/universal.py
@@ -424,6 +424,10 @@ def is_account_number_valid(prefix: str, account_number: str) -> bool:
     :param account_number:          str, The main part of the account number.
     :return                         bool, True if the account number is valid, False otherwise.
     """
+
+    if not (isinstance(prefix, str) and isinstance(account_number, str)):
+        raise ValueError("Both prefix and account number must be strings.")
+
     # https://www.ecbs.org/Download/Tr201v3.9.pdf
     weights = [6, 3, 7, 9, 10, 5, 8, 4, 2, 1]
     prefix_sum = 0


### PR DESCRIPTION
This commit introduces the `is_account_number_valid` function to the urpautils library. This function applies a weighted checksum validation to account numbers, conforming to the ECBS (European Committee for Banking Standards) guidelines. It's particularly useful for verifying the accuracy of account numbers extracted from various sources like systems or PDF documents, ensuring their validity before they are used or processed further.
